### PR TITLE
Add missing dot on the bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,7 @@
                         <li>
                           <a href="#usage">Usage</a>
                         </li>
+                        <li class="footer-menu-divider">&sdot;</li>
                         <li>
                           <a href="#install">Install</a>
                         </li>


### PR DESCRIPTION
Missing dot between "Usage" and "Install" in GitHub page
![screen shot 2015-10-08 at 12 59 45 pm](https://cloud.githubusercontent.com/assets/6943514/10363313/83efc2b8-6dbc-11e5-920d-be93386fe636.png)
